### PR TITLE
Updated the pages for Wanaku 0.1.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@ setup:
 	npm add -D vitepress
 	npm i vitepress-plugin-mermaid mermaid -D
 
-WANAKU_ROUTER_VERSIONS=0.0.8 0.0.9
+WANAKU_ROUTER_VERSIONS=0.0.9 0.1.0
 DEMOS_DIR=demos
 VERSIONS_DIR=version
 TOOLSETS_DIR=toolsets
 
-WCJSDK_VERSIONS=0.0.9
+WCJSDK_VERSIONS=0.1.0
 WCJSDK_DIR=java-sdk
 
-CAMEL_INTEGRATION_CAPABILITY_VERSIONS=0.0.9 main
+CAMEL_INTEGRATION_CAPABILITY_VERSIONS=0.1.0 main
 CAMEL_INTEGRATION_CAPABILITY_DIR=camel-integration-capability
 
 .PHONY: docs demos

--- a/camel-integration-capability/index.md
+++ b/camel-integration-capability/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Camel Integration Capability (current version)
-      link: /camel-integration-capability/camel-integration-capability-0.0.9/
+      link: /camel-integration-capability/camel-integration-capability-0.1.0/
 
 features:
   - title: Camel Integration Capability (pre-release)

--- a/demos/index.md
+++ b/demos/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Wanaku (current version)
-      link: /demos/wanaku-demos-0.0.9/
+      link: /demos/wanaku-demos-0.1.0/
     - theme: alt
       text: Wanaku Next (pre-release)
       link: /demos/wanaku-demos-main/

--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ hero:
   actions:
     - theme: brand
       text: Wanaku (current version)
-      link: /version/wanaku-0.0.9/
+      link: /version/wanaku-0.1.0/
     - theme: alt
       text: Wanaku Next (Pre-release)
       link: /version/wanaku-main/

--- a/java-sdk/index.md
+++ b/java-sdk/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Wanaku Java Capability SDK (current version)
-      link: /java-sdk/wanaku-capabilities-java-sdk-0.0.9/
+      link: /java-sdk/wanaku-capabilities-java-sdk-0.1.0/
 
 features:
   - title: Wanaku Java Capability SDK (pre-release)

--- a/toolsets/index.md
+++ b/toolsets/index.md
@@ -8,7 +8,7 @@ hero:
 
 features:
   - title: Wanaku ToolSets (current version)
-    link: /toolsets/wanaku-toolsets-0.0.9/README
+    link: /toolsets/wanaku-toolsets-0.1.0/README
   - title: Wanaku ToolSets Next (pre-release)
     link: /toolsets/wanaku-toolsets-main/README
 ---


### PR DESCRIPTION
## Summary
- Bump current version references from 0.0.9 to 0.1.0 across all landing pages and Makefile
- Drop older version 0.0.8 from the router versions list, keeping only 0.0.9 and 0.1.0

## Test plan
- [ ] Verify `make fetch` clones the correct 0.1.0 branches
- [ ] Verify all landing page links resolve to the new 0.1.0 documentation