### PR TITLE
Use current alias instead of version-specific paths

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,6 @@
+RewriteEngine On
+
+RewriteRule ^docs/version/wanaku-0\.0\.8/(.*) /docs/version/wanaku-current/$1 [R=301,L]
+RewriteRule ^docs/version/wanaku-0\.0\.9/(.*) /docs/version/wanaku-current/$1 [R=301,L]
+RewriteRule ^docs/version/wanaku-0\.1\.0/(.*) /docs/version/wanaku-current/$1 [R=301,L]
+RewriteRule ^docs/version/wanaku-0\.1\.1/(.*) /docs/version/wanaku-current/$1 [R=301,L]

--- a/Makefile
+++ b/Makefile
@@ -2,31 +2,27 @@ setup:
 	npm add -D vitepress
 	npm i vitepress-plugin-mermaid mermaid -D
 
-WANAKU_ROUTER_VERSIONS=0.1.1
+WANAKU_CURRENT_VERSION=0.1.1
 DEMOS_DIR=demos
-DEMOS_VERSIONS=0.1.1
 VERSIONS_DIR=version
-
-WCJSDK_VERSIONS=0.1.1
 WCJSDK_DIR=java-sdk
-
-CAMEL_INTEGRATION_CAPABILITY_VERSIONS=0.1.1 main
 CAMEL_INTEGRATION_CAPABILITY_DIR=camel-integration-capability
 
 .PHONY: docs demos
 
-$(WANAKU_ROUTER_VERSIONS):
-	@if [ ! -e $(VERSIONS_DIR)/wanaku-$(@) ]; then \
-  		git clone --branch wanaku-$(@) https://github.com/wanaku-ai/wanaku $(VERSIONS_DIR)/wanaku-$(@) ; \
-  	fi
+router-current:
+	@if [ ! -e $(VERSIONS_DIR)/wanaku-current ]; then \
+		git clone --branch wanaku-$(WANAKU_CURRENT_VERSION) https://github.com/wanaku-ai/wanaku $(VERSIONS_DIR)/wanaku-current ; \
+	fi
+
 router-main:
 	@if [ ! -e $(VERSIONS_DIR)/wanaku-main ]; then \
-  		git clone --branch main https://github.com/wanaku-ai/wanaku $(VERSIONS_DIR)/wanaku-main ; \
-  	fi ;
+		git clone --branch main https://github.com/wanaku-ai/wanaku $(VERSIONS_DIR)/wanaku-main ; \
+	fi
 
-wanaku-demos-$(DEMOS_VERSIONS):
-	@if [ ! -e $(DEMOS_DIR)/$(@) ]; then \
-		git clone --branch $(@) https://github.com/wanaku-ai/wanaku-demos $(DEMOS_DIR)/$(@) ; \
+demos-current:
+	@if [ ! -e $(DEMOS_DIR)/wanaku-demos-current ]; then \
+		git clone --branch wanaku-demos-$(WANAKU_CURRENT_VERSION) https://github.com/wanaku-ai/wanaku-demos $(DEMOS_DIR)/wanaku-demos-current ; \
 	fi
 
 demos-main:
@@ -34,41 +30,42 @@ demos-main:
 		git clone --branch main https://github.com/wanaku-ai/wanaku-demos $(DEMOS_DIR)/wanaku-demos-main ; \
 	fi
 
-demos: wanaku-demos-$(DEMOS_VERSIONS) demos-main
+demos: demos-current demos-main
 
-wanaku-capabilities-java-sdk-$(WCJSDK_VERSIONS):
-	@if [ ! -e $(WCJSDK_DIR)/$(@) ]; then \
-		git clone --branch $(@) https://github.com/wanaku-ai/wanaku-capabilities-java-sdk $(WCJSDK_DIR)/$(@) ; \
+wcjsdk-current:
+	@if [ ! -e $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-current ]; then \
+		git clone --branch wanaku-capabilities-java-sdk-$(WANAKU_CURRENT_VERSION) https://github.com/wanaku-ai/wanaku-capabilities-java-sdk $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-current ; \
 	fi
 
-wanaku-capabilities-java-sdk: wanaku-capabilities-java-sdk-$(WCJSDK_VERSIONS)
+wcjsdk-main:
 	@if [ ! -e $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-main ]; then \
 		git clone --branch main https://github.com/wanaku-ai/wanaku-capabilities-java-sdk $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-main ; \
 	fi
 
+wanaku-capabilities-java-sdk: wcjsdk-current wcjsdk-main
 
-camel-integration-capability-$(CAMEL_INTEGRATION_CAPABILITY_VERSIONS):
-	@if [ ! -e $(CAMEL_INTEGRATION_CAPABILITY_DIR)/$(@) ]; then \
-		git clone --branch $(@) https://github.com/wanaku-ai/camel-integration-capability $(CAMEL_INTEGRATION_CAPABILITY_DIR)/$(@) ; \
+cic-current:
+	@if [ ! -e $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-current ]; then \
+		git clone --branch camel-integration-capability-$(WANAKU_CURRENT_VERSION) https://github.com/wanaku-ai/camel-integration-capability $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-current ; \
 	fi
 
-camel-integration-capability: camel-integration-capability-$(CAMEL_INTEGRATION_CAPABILITY_VERSIONS)
+cic-main:
 	@if [ ! -e $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-main ]; then \
 		git clone --branch main https://github.com/wanaku-ai/camel-integration-capability $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-main ; \
 	fi
 
-main: router-main demos-main camel-integration-capability wanaku-capabilities-java-sdk
+camel-integration-capability: cic-current cic-main
 
-fetch: $(WANAKU_ROUTER_VERSIONS) demos main
+fetch: router-current router-main demos camel-integration-capability wanaku-capabilities-java-sdk
 
 docs: fetch
 	npm run docs:build
 
 clean:
-	@rm -rf $(VERSIONS_DIR)/wanaku-*
-	@rm -rf $(DEMOS_DIR)/wanaku-*
-	@rm -rf $(WCJSDK_DIR)/wanaku-*
-	@rm -rf $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-*
+	@rm -rf $(VERSIONS_DIR)/wanaku-current $(VERSIONS_DIR)/wanaku-main
+	@rm -rf $(DEMOS_DIR)/wanaku-demos-current $(DEMOS_DIR)/wanaku-demos-main
+	@rm -rf $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-current $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-main
+	@rm -rf $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-current $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-main
 	@rm -rf docs
 
 serve:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ setup:
 	npm add -D vitepress
 	npm i vitepress-plugin-mermaid mermaid -D
 
-WANAKU_CURRENT_VERSION=0.1.1
+WANAKU_ROUTER_VERSION=0.1.1
+WANAKU_DEMOS_VERSION=0.1.1
+WCJSDK_VERSION=0.1.1
+CAMEL_INTEGRATION_CAPABILITY_VERSION=0.1.1
+
 DEMOS_DIR=demos
 VERSIONS_DIR=version
 WCJSDK_DIR=java-sdk
@@ -12,7 +16,7 @@ CAMEL_INTEGRATION_CAPABILITY_DIR=camel-integration-capability
 
 router-current:
 	@if [ ! -e $(VERSIONS_DIR)/wanaku-current ]; then \
-		git clone --branch wanaku-$(WANAKU_CURRENT_VERSION) https://github.com/wanaku-ai/wanaku $(VERSIONS_DIR)/wanaku-current ; \
+		git clone --branch wanaku-$(WANAKU_ROUTER_VERSION) https://github.com/wanaku-ai/wanaku $(VERSIONS_DIR)/wanaku-current ; \
 	fi
 
 router-main:
@@ -22,7 +26,7 @@ router-main:
 
 demos-current:
 	@if [ ! -e $(DEMOS_DIR)/wanaku-demos-current ]; then \
-		git clone --branch wanaku-demos-$(WANAKU_CURRENT_VERSION) https://github.com/wanaku-ai/wanaku-demos $(DEMOS_DIR)/wanaku-demos-current ; \
+		git clone --branch wanaku-demos-$(WANAKU_DEMOS_VERSION) https://github.com/wanaku-ai/wanaku-demos $(DEMOS_DIR)/wanaku-demos-current ; \
 	fi
 
 demos-main:
@@ -34,7 +38,7 @@ demos: demos-current demos-main
 
 wcjsdk-current:
 	@if [ ! -e $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-current ]; then \
-		git clone --branch wanaku-capabilities-java-sdk-$(WANAKU_CURRENT_VERSION) https://github.com/wanaku-ai/wanaku-capabilities-java-sdk $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-current ; \
+		git clone --branch wanaku-capabilities-java-sdk-$(WCJSDK_VERSION) https://github.com/wanaku-ai/wanaku-capabilities-java-sdk $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-current ; \
 	fi
 
 wcjsdk-main:
@@ -46,7 +50,7 @@ wanaku-capabilities-java-sdk: wcjsdk-current wcjsdk-main
 
 cic-current:
 	@if [ ! -e $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-current ]; then \
-		git clone --branch camel-integration-capability-$(WANAKU_CURRENT_VERSION) https://github.com/wanaku-ai/camel-integration-capability $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-current ; \
+		git clone --branch camel-integration-capability-$(CAMEL_INTEGRATION_CAPABILITY_VERSION) https://github.com/wanaku-ai/camel-integration-capability $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-current ; \
 	fi
 
 cic-main:

--- a/camel-integration-capability/index.md
+++ b/camel-integration-capability/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Camel Integration Capability (current version)
-      link: /camel-integration-capability/camel-integration-capability-0.1.1/
+      link: /camel-integration-capability/camel-integration-capability-current/
 
 features:
   - title: Camel Integration Capability (pre-release)

--- a/demos/index.md
+++ b/demos/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Wanaku Guided Demos (current version)
-      link: /demos/wanaku-demos-0.1.1/
+      link: /demos/wanaku-demos-current/
 
 features:
   - title: Wanaku Guided Demos (pre-release)

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ hero:
 features:
   - title: Wanaku (current version)
     details: Reference Wanaku documentation (current version)
-    link: /version/wanaku-0.1.1/
+    link: /version/wanaku-current/
   - title: Wanaku Next (pre-release)
     details: Reference Wanaku documentation (pre-release)
     link: /version/wanaku-main/

--- a/java-sdk/index.md
+++ b/java-sdk/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Wanaku Java Capability SDK (current version)
-      link: /java-sdk/wanaku-capabilities-java-sdk-0.1.1/
+      link: /java-sdk/wanaku-capabilities-java-sdk-current/
 
 features:
   - title: Wanaku Java Capability SDK (pre-release)

--- a/toolsets/index.md
+++ b/toolsets/index.md
@@ -8,7 +8,7 @@ hero:
 
 features:
   - title: Wanaku ToolSets (current version)
-    link: /toolsets/wanaku-toolsets-0.1.1/README
+    link: /toolsets/wanaku-toolsets-current/README
   - title: Wanaku ToolSets Next (pre-release)
     link: /toolsets/wanaku-toolsets-main/README
 ---


### PR DESCRIPTION
## Summary
- Replace per-version variables with per-component version variables (`WANAKU_ROUTER_VERSION`, `WANAKU_DEMOS_VERSION`, `WCJSDK_VERSION`, `CAMEL_INTEGRATION_CAPABILITY_VERSION`) so each component can be released independently
- Clone targets now write to `-current` directories instead of version-specific ones (e.g., `wanaku-current` instead of `wanaku-0.1.1`)
- Update all `index.md` links to use `-current` paths so they never need changing on release
- Add `.htaccess` with Apache rewrite rules to 301 redirect old versioned URLs (0.0.8, 0.0.9, 0.1.0, 0.1.1) to `wanaku-current`, preserving deep links

## Test plan
- [ ] Run `make clean && make fetch` and verify all repos clone correctly into `-current` and `-main` directories
- [ ] Run `make serve` and verify all index page links resolve correctly
- [ ] Verify `.htaccess` redirects work on Dreamhost (e.g., `/docs/version/wanaku-0.1.1/` redirects to `/docs/version/wanaku-current/`)