### PR TITLE
chore: fetch and deploy get-wanaku.sh installer script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,11 +53,16 @@ jobs:
           make fetch
       - name: Build with VitePress
         run: make docs
-      - name: Upload artifact
+      - name: Upload docs artifact
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           path: docs
           name: docs
+      - name: Upload get-wanaku.sh artifact
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        with:
+          path: get-wanaku.sh
+          name: get-wanaku
 
 
   # Deployment job
@@ -69,15 +74,31 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy
     steps:
-      - name: download archived artifacts
+      - name: download docs artifact
         uses: actions/download-artifact@v4
         with:
             name: docs
-      - name: copy file via ssh password
+            path: docs
+      - name: download get-wanaku.sh artifact
+        uses: actions/download-artifact@v4
+        with:
+            name: get-wanaku
+            path: scripts
+      - name: deploy docs via scp
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.WEBSITE_HOST }}
           username: ${{ secrets.WEBSITE_USERNAME }}
           key: ${{ secrets.WANAKU_KEY }}
-          source: "."
+          source: "docs/*"
           target: wanaku.ai/docs
+          strip_components: 1
+      - name: deploy get-wanaku.sh via scp
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.WEBSITE_HOST }}
+          username: ${{ secrets.WEBSITE_USERNAME }}
+          key: ${{ secrets.WANAKU_KEY }}
+          source: "scripts/get-wanaku.sh"
+          target: wanaku.ai
+          strip_components: 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vitepress/cache/
 node_modules/
+get-wanaku.sh

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,10 @@ cic-main:
 
 camel-integration-capability: cic-current cic-main
 
-fetch: router-current router-main demos camel-integration-capability wanaku-capabilities-java-sdk
+get-wanaku:
+	curl -sSL -o get-wanaku.sh https://raw.githubusercontent.com/wanaku-ai/wanaku/refs/heads/main/get-wanaku.sh
+
+fetch: router-current router-main demos camel-integration-capability wanaku-capabilities-java-sdk get-wanaku
 
 docs: fetch
 	npm run docs:build
@@ -71,6 +74,7 @@ clean:
 	@rm -rf $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-current $(WCJSDK_DIR)/wanaku-capabilities-java-sdk-main
 	@rm -rf $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-current $(CAMEL_INTEGRATION_CAPABILITY_DIR)/camel-integration-capability-main
 	@rm -rf docs
+	@rm -f get-wanaku.sh
 
 serve:
 	npm run docs:dev


### PR DESCRIPTION
## Summary
- Adds a Makefile target to fetch `get-wanaku.sh` from the main Wanaku repo during build
- Deploys the script to the website root so users can install via `curl -sSL https://wanaku.ai/get-wanaku.sh | bash`
- Adds `get-wanaku.sh` to `.gitignore` since it's a fetched artifact

## Test plan
- [ ] Verify the CI build fetches `get-wanaku.sh` successfully
- [ ] Verify the script is deployed to `wanaku.ai/get-wanaku.sh`
- [ ] Confirm `curl -sSL https://wanaku.ai/get-wanaku.sh` returns the installer script