### PR TITLE
chore: add blog post announcing Wanaku 0.1.3 release

### DIFF
--- a/blog/posts/2026-06-05-wanaku-0.1.3-release.md
+++ b/blog/posts/2026-06-05-wanaku-0.1.3-release.md
@@ -38,7 +38,13 @@ Version 0.1.2 and 0.1.3 focused on stability:
 
 ## Get Started
 
-Download the latest release from [GitHub Releases](https://github.com/wanaku-ai/wanaku/releases/tag/v0.1.3) or install the CLI with JBang:
+Install Wanaku with the installer script:
+
+```bash
+curl -sSL https://wanaku.ai/get-wanaku.sh | bash
+```
+
+On Windows or if you prefer JBang:
 
 ```bash
 jbang app install wanaku@wanaku-ai/wanaku

--- a/blog/posts/2026-06-05-wanaku-0.1.3-release.md
+++ b/blog/posts/2026-06-05-wanaku-0.1.3-release.md
@@ -1,0 +1,47 @@
+---
+title: "Wanaku 0.1.3 Released"
+date: 2026-06-05
+author: Wanaku Team
+tags:
+  - release
+  - announcement
+description: "Wanaku 0.1.3 is out with new GitHub tools, service template improvements, non-blocking MCP operations, and a Quarkus 3.33.2 upgrade."
+---
+
+# Wanaku 0.1.3 Released
+
+We are happy to announce the release of Wanaku 0.1.3, the latest version of the open-source MCP Router. This release wraps up a series of improvements delivered across 0.1.1, 0.1.2, and 0.1.3, bringing new capabilities, better stability, and a smoother developer experience.
+
+## New Features
+
+**GitHub Tools** — Wanaku now ships with GitHub Pull Request tools, including a PR comments tool and a PR source tool with parameterized settings and API integration. These let AI agents interact with GitHub pull requests directly through Wanaku.
+
+**Non-Blocking MCP Operations** — MCP tool invocations and resource acquisitions are now fully non-blocking, replacing the previous blocking approach with reactive concurrency for better throughput and responsiveness.
+
+**Service Template Properties** — The CLI now supports `--property` and `--properties-from` flags when instantiating service templates, making it easier to configure templates without editing files manually.
+
+**LLM Model Suggestions** — The UI now suggests LLM models based on the configured base URL, and the API key field is now optional for local LLM providers.
+
+**UI Improvements** — Empty table states, enhanced resource parameter editing, and a fix for the LLM model field in Firefox round out the frontend updates.
+
+## Stability and Fixes
+
+Version 0.1.2 and 0.1.3 focused on stability:
+
+- **CLI launch scripts** unified to support both JAR and native binary distributions
+- **OIDC tenant identifiers** corrected from `ns-1..ns-10` to `ns-0..ns-9`
+- **RuntimeConstants initialization** deferred to runtime, fixing a startup issue
+- **Quarkus upgraded to 3.33.2**, picking up the latest framework improvements
+- **Deprecated Tavily tool** removed in favor of newer alternatives
+- Improved error messages for non-existing service templates
+- gRPC cancellation handling added to tool and resource emitters
+
+## Get Started
+
+Download the latest release from [GitHub Releases](https://github.com/wanaku-ai/wanaku/releases/tag/v0.1.3) or install the CLI with JBang:
+
+```bash
+jbang app install wanaku@wanaku-ai/wanaku
+```
+
+Check the [documentation](/docs/) to learn more, and report issues on [GitHub](https://github.com/wanaku-ai/wanaku/issues).


### PR DESCRIPTION
## Summary

- Adds a blog post announcing the Wanaku 0.1.3 release
- Covers new features from 0.1.1 (GitHub tools, non-blocking MCP, service template properties, UI improvements) and stability fixes from 0.1.2/0.1.3 (CLI unification, OIDC fix, Quarkus 3.33.2 upgrade)

## Test plan

- [ ] Verify blog post renders correctly on the site
- [ ] Check that the blog listing page picks up the new post