### PR TITLE
Add blog post about the new website

### DIFF
--- a/blog/posts/2026-06-05-new-wanaku-website.md
+++ b/blog/posts/2026-06-05-new-wanaku-website.md
@@ -1,0 +1,33 @@
+---
+title: "Welcome to the New Wanaku Website"
+date: 2026-06-05
+author: Wanaku Team
+tags:
+  - announcement
+  - website
+description: "The Wanaku project has a new home — a full website with a homepage, blog, community page, and reorganized documentation."
+---
+
+# Welcome to the New Wanaku Website
+
+We are excited to announce that wanaku.ai has been rebuilt from the ground up. What was previously a documentation-only site is now a full project website with dedicated sections for the homepage, blog, community, and about pages — all alongside the existing documentation.
+
+## What's New
+
+**Homepage** — The site now opens with a proper landing page that introduces Wanaku and its core value: eliminating repetitive integration configurations, strengthening security and compliance, and scaling without stress.
+
+**Blog** — You're reading it! The new blog section includes an RSS/Atom feed so you can follow project updates in your favorite reader. We've migrated the original "Introducing Wanaku" post and will continue publishing release announcements and technical content here.
+
+**Community** — A dedicated page that brings together all the ways to get involved: GitHub Discussions, the contributing guide, the YouTube channel, and links to all project repositories including the Camel Integration Capability and the Capabilities Java SDK.
+
+**About** — Learn about the challenge Wanaku solves, the approach we take, and the story behind the project name (hint: it involves a South American camelid).
+
+## Reorganized Documentation
+
+The documentation now lives under the `/docs/` path, keeping technical reference material cleanly separated from the rest of the site. All existing documentation links have been preserved through redirects, so bookmarks and shared links continue to work.
+
+## Built with VitePress
+
+The entire site is built with [VitePress](https://vitepress.dev/), giving us fast builds, a clean developer experience, and a modern look. The source is open on [GitHub](https://github.com/wanaku-ai/wanaku-docs) — contributions are welcome.
+
+We hope you enjoy the new site. Check out the [community page](/community/) to get involved, or head to the [documentation](/docs/) to start building with Wanaku.


### PR DESCRIPTION
## Summary
- Adds a blog post announcing the new wanaku.ai website
- Covers the homepage, blog with RSS, community page, about page, docs reorganization, and VitePress stack

## Test plan
- [ ] Verify the blog post renders correctly on the site
- [ ] Confirm it appears in the blog listing page