### PR TITLE
Add SEO infrastructure to the website

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -3,6 +3,8 @@ import { withMermaid } from "vitepress-plugin-mermaid";
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs';
 import { genFeed } from './genFeed'
 
+const siteUrl = 'https://wanaku.ai'
+
 // https://vitepress.dev/reference/site-config + mermaid
 export default withMermaid({
     title: "Wanaku",
@@ -11,6 +13,83 @@ export default withMermaid({
     base: '/',
     outDir: 'dist',
     srcExclude: ['**/node_modules/**', 'camel-integration-capability/main/**'],
+
+    sitemap: {
+        hostname: siteUrl
+    },
+
+    transformPageData(pageData) {
+        const isHome = pageData.relativePath === 'index.md'
+        const isBlogPost = pageData.relativePath.startsWith('blog/posts/')
+
+        const title = isHome
+            ? 'Wanaku — The First Open-Source MCP Router'
+            : `${pageData.title} | Wanaku`
+
+        const description = pageData.description || 'The first open-source MCP Router for AI workflows'
+
+        const canonicalUrl = `${siteUrl}/${pageData.relativePath}`
+            .replace(/index\.md$/, '')
+            .replace(/\.md$/, '.html')
+
+        const ogImage = `${siteUrl}${pageData.frontmatter.image || '/images/wanaku.png'}`
+
+        const ogType = isBlogPost ? 'article' : 'website'
+
+        pageData.frontmatter.head ??= []
+        pageData.frontmatter.head.push(
+            ['link', { rel: 'canonical', href: canonicalUrl }],
+            ['meta', { property: 'og:title', content: title }],
+            ['meta', { property: 'og:description', content: description }],
+            ['meta', { property: 'og:url', content: canonicalUrl }],
+            ['meta', { property: 'og:type', content: ogType }],
+            ['meta', { property: 'og:image', content: ogImage }],
+            ['meta', { property: 'og:site_name', content: 'Wanaku' }],
+            ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+            ['meta', { name: 'twitter:title', content: title }],
+            ['meta', { name: 'twitter:description', content: description }],
+            ['meta', { name: 'twitter:image', content: ogImage }],
+        )
+
+        if (isHome) {
+            pageData.frontmatter.head.push(
+                ['script', { type: 'application/ld+json' }, JSON.stringify({
+                    '@context': 'https://schema.org',
+                    '@type': 'Organization',
+                    name: 'Wanaku',
+                    url: siteUrl,
+                    logo: `${siteUrl}/images/wanaku.png`,
+                    sameAs: [
+                        'https://github.com/wanaku-ai/',
+                        'https://www.youtube.com/@WanakuAI'
+                    ]
+                })],
+                ['script', { type: 'application/ld+json' }, JSON.stringify({
+                    '@context': 'https://schema.org',
+                    '@type': 'WebSite',
+                    name: 'Wanaku',
+                    url: siteUrl
+                })]
+            )
+        }
+
+        if (isBlogPost) {
+            pageData.frontmatter.head.push(
+                ['script', { type: 'application/ld+json' }, JSON.stringify({
+                    '@context': 'https://schema.org',
+                    '@type': 'BlogPosting',
+                    headline: pageData.frontmatter.title || pageData.title,
+                    datePublished: pageData.frontmatter.date,
+                    author: {
+                        '@type': 'Person',
+                        name: pageData.frontmatter.author || 'Wanaku Team'
+                    },
+                    description: description
+                })]
+            )
+        }
+    },
+
     themeConfig: {
         // https://vitepress.dev/reference/default-theme-config
         nav: [

--- a/about/index.md
+++ b/about/index.md
@@ -1,5 +1,6 @@
 ---
 layout: home
+description: "Learn about Wanaku — the open-source MCP Router connecting AI agents to enterprise systems securely."
 
 hero:
   name: "About Wanaku"

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Blog
+description: "News, releases, and technical articles from the Wanaku project."
 ---
 
 <script setup>

--- a/community/index.md
+++ b/community/index.md
@@ -1,5 +1,6 @@
 ---
 layout: home
+description: "Join the Wanaku community — contribute, discuss, and watch demos of the open-source MCP Router."
 
 hero:
   name: "Community"

--- a/docs/demos/index.md
+++ b/docs/demos/index.md
@@ -1,6 +1,7 @@
 ---
 # https://vitepress.dev/reference/default-theme-home-page
 layout: home
+description: "Step-by-step guided demos to learn the Wanaku MCP Router from first tool to production deployment."
 
 hero:
   name: "Wanaku MCP Router Demos"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 # https://vitepress.dev/reference/default-theme-home-page
 layout: home
+description: "Documentation for the Wanaku MCP Router — guides, API reference, demos, and SDK docs."
 
 hero:
   name: "Wanaku MCP Router"

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,8 +10,8 @@ The project name comes from the origins of the word [Guanaco](https://en.wikiped
 South America.
 
 ## Core Content
-- [Documentation](https://wanaku.ai/docs/): The project documentation
-- [Project Organization](https://github.com/wanaku-ai/): The project documentation
-- [Project Main Repository](https://github.com/wanaku-ai/wanaku): The project documentation
+- [Documentation](https://wanaku.ai/docs/): Guides, API reference, demos, and SDK docs
+- [Project Organization](https://github.com/wanaku-ai/): GitHub organization with all Wanaku repositories
+- [Project Main Repository](https://github.com/wanaku-ai/wanaku): Source code for the Wanaku MCP Router
 - [Project Releases](https://github.com/wanaku-ai/wanaku/releases): Wanaku releases for download
-- [Project Examples](https://github.com/wanaku-ai/wanaku-examples): Wanaku releases for download
+- [Project Examples](https://github.com/wanaku-ai/wanaku-examples): Example configurations and integrations

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,12 @@
+User-agent: *
+Crawl-delay: 10
+Disallow: /admin/
+Disallow: /includes/
+Disallow: /config/
+Disallow: /logs/
+Disallow: /backup/
+Disallow: /.env
+Disallow: /wp-admin/
+Disallow: /wp-includes/
+
+Sitemap: https://wanaku.ai/sitemap.xml


### PR DESCRIPTION
## Summary
- Add sitemap generation, OpenGraph/Twitter Card meta tags, canonical URLs, and JSON-LD structured data via VitePress `transformPageData` hook
- Add `robots.txt` with sitemap reference and existing Disallow directives
- Add unique per-page `description` frontmatter to docs, about, community, blog, and demos hub pages
- Fix duplicated link descriptions in `docs/llms.txt`

## Test plan
- [ ] Run `npm run docs:build` and verify `dist/sitemap.xml` and `dist/robots.txt` exist
- [ ] Inspect built HTML `<head>` for OG, Twitter, canonical, and JSON-LD tags
- [ ] Validate social sharing preview after deploy (Twitter Card Validator / LinkedIn Post Inspector)