### PR TITLE
chore: exclude tests/plans from VitePress build

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -11,7 +11,7 @@ export default defineConfig({
     ignoreDeadLinks: true,
     base: '/',
     outDir: 'dist',
-    srcExclude: ['**/node_modules/**', 'camel-integration-capability/main/**'],
+    srcExclude: ['**/node_modules/**', 'camel-integration-capability/main/**', '**/tests/plans/**'],
 
     sitemap: {
         hostname: siteUrl


### PR DESCRIPTION
## Summary
- Add `**/tests/plans/**` to `srcExclude` in VitePress config to prevent test plan markdown files from being rendered during the site build.
- Fixes the CI build failure caused by Vue template parser choking on `{{ }}` interpolation in test plan files (e.g., `operator-helm-clusterrolebinding-naming.md`).